### PR TITLE
updating botinfo keyerror

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -146,7 +146,7 @@ class UtilityCog(commands.Cog, name="Utility"):
                         value=str(db_bot["serverCount"]))
         embed.add_field(name=f"{self.bot.settings['emoji']['url']} Listing URL",
                         value=f"{self.bot.settings['website']['url']}/bots/{db_bot['_id']}", inline=False)
-        embed.set_thumbnail(url=f"{db_bot['avatar']['url']}")
+        embed.set_thumbnail(url=bot.avatar_url)
 
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
Not really the way this fix is should be fixed but doing that since don't want to be getting KeyError's for majority of bots 

('avatar' is not in the mongodb document with all the other bot info, someone who has access to db should make sure that 'avatar' exists in the db)